### PR TITLE
View and presenters auto escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ The output of views and presenters is always **autoescaped**.
 
 **ATTENTION:** In order to prevent XSS attacks, please read the instructions below.
 Because Lotus::View supports a lot of template engines, the escape happens at the level of the view.
-Most of the times everything happens automatically, but there are still some corner cases that need your manual intervention.
+Most of the time everything happens automatically, but there are still some corner cases that need your manual intervention.
 
 #### View autoescape
 
@@ -685,10 +685,10 @@ presenter.name # => "&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;"
 
 #### Escape entire objects
 
-We have seen that concrete methods are in views are automatically escaped.
-This is great, but tedious if you need to print a lot of informations from a given object.
+We have seen that concrete methods in views are automatically escaped.
+This is great, but tedious if you need to print a lot of information from a given object.
 
-Imagine to have `user` as part of the view locals.
+Imagine you have `user` as part of the view locals.
 If you want to use `<%= user.name %>` directly, **you're still vulnerable to XSS attacks**.
 
 You have two alternatives:

--- a/README.md
+++ b/README.md
@@ -659,11 +659,28 @@ user = User.new("<script>alert('xss')</script>")
 # THIS IS USEFUL FOR UNIT TESTING:
 template = Lotus::View::Template.new('users/show.html.erb')
 view     = Users::Show.new(template, user: user)
-view.user_name # => &lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;
+view.user_name # => "&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;"
 
-# THIS IS RENDERING OUTPUT:
+# THIS IS THE RENDERING OUTPUT:
 Users::Show.render(format: :html, user: user)
 # => <div id="user_name">&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;</div>
+```
+
+#### Presenter autoescape
+
+```ruby
+require 'lotus/view'
+
+User = Struct.new(:name)
+
+class UserPresenter
+  include Lotus::Presenter
+end
+
+user      = User.new("<script>alert('xss')</script>")
+presenter = UserPresenter.new(user)
+
+presenter.name # => "&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;"
 ```
 
 #### Escape entire objects

--- a/lib/lotus/presenter.rb
+++ b/lib/lotus/presenter.rb
@@ -1,3 +1,5 @@
+require 'lotus/view/escape'
+
 module Lotus
   # Presenter pattern implementation
   #
@@ -49,6 +51,10 @@ module Lotus
   #   # it has private access to the original object
   #   puts presenter.inspect_object # => #<Map:0x007fdeada0b2f0 @locations=["Rome", "Boston"]>
   module Presenter
+    def self.included(base)
+      base.extend ::Lotus::View::Escape
+    end
+
     # Initialize the presenter
     #
     # @param object [Object] the object to present
@@ -65,7 +71,7 @@ module Lotus
     # @since 0.1.0
     def method_missing(m, *args, &blk)
       if @object.respond_to?(m)
-        @object.__send__ m, *args, &blk
+        ::Lotus::View::Escape.html(@object.__send__(m, *args, &blk))
       else
         super
       end

--- a/lib/lotus/presenter.rb
+++ b/lib/lotus/presenter.rb
@@ -3,9 +3,13 @@ require 'lotus/view/escape'
 module Lotus
   # Presenter pattern implementation
   #
+  # It delegates to the wrapped object the missing method invocations.
+  #
+  # The output of concrete and delegated methods is escaped as XSS prevention.
+  #
   # @since 0.1.0
   #
-  # @example
+  # @example Basic usage
   #   require 'lotus/view'
   #
   #   class Map
@@ -50,7 +54,41 @@ module Lotus
   #
   #   # it has private access to the original object
   #   puts presenter.inspect_object # => #<Map:0x007fdeada0b2f0 @locations=["Rome", "Boston"]>
+  #
+  # @example Escape
+  #   require 'lotus/view'
+  #
+  #   User = Struct.new(:first_name, :last_name)
+  #
+  #   class UserPresenter
+  #     include Lotus::Presenter
+  #
+  #     def full_name
+  #       [first_name, last_name].join(' ')
+  #     end
+  #
+  #     def raw_first_name
+  #       _raw first_name
+  #     end
+  #   end
+  #
+  #   first_name = '<script>alert('xss')</script>'
+  #
+  #   user = User.new(first_name, nil)
+  #   presenter = UserPresenter.new(user)
+  #
+  #   presenter.full_name
+  #     # => "&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;"
+  #
+  #   presenter.raw_full_name
+  #      # => "<script>alert('xss')</script>"
   module Presenter
+    # Inject escape logic into the given class.
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::View::Escape
     def self.included(base)
       base.extend ::Lotus::View::Escape
     end

--- a/lib/lotus/view.rb
+++ b/lib/lotus/view.rb
@@ -5,6 +5,7 @@ require 'lotus/view/version'
 require 'lotus/view/configuration'
 require 'lotus/view/inheritable'
 require 'lotus/view/rendering'
+require 'lotus/view/escape'
 require 'lotus/view/dsl'
 require 'lotus/layout'
 require 'lotus/presenter'
@@ -270,6 +271,7 @@ module Lotus
         extend Inheritable.dup
         extend Dsl.dup
         extend Rendering.dup
+        extend Escape.dup
 
         include Utils::ClassAttribute
         class_attribute :configuration

--- a/lib/lotus/view/escape.rb
+++ b/lib/lotus/view/escape.rb
@@ -1,0 +1,44 @@
+require 'lotus/utils/escape'
+
+module Lotus
+  module View
+    module Escape
+      def self.html(input)
+        case input
+        when String
+          Utils::Escape.html(input)
+        else
+          input
+        end
+      end
+
+      def self.extended(base)
+        base.class_eval do
+          include Lotus::Utils::ClassAttribute
+          include InstanceMethods
+
+          class_attribute :autoescape_methods
+          self.autoescape_methods = {}
+        end
+      end
+
+      def method_added(method_name)
+        unless autoescape_methods[method_name]
+          prepend Module.new {
+            module_eval %{
+              def #{ method_name }(*args, &blk); ::Lotus::View::Escape.html super; end
+            }
+          }
+
+          autoescape_methods[method_name] = true
+        end
+      end
+
+      module InstanceMethods
+        def raw(input)
+          Lotus::Utils::Escape::SafeString.new(input)
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/view/escape.rb
+++ b/lib/lotus/view/escape.rb
@@ -3,21 +3,140 @@ require 'lotus/presenter'
 
 module Lotus
   module View
+    # Auto escape logic for views and presenters.
+    #
+    # @since x.x.x
     module Escape
       module InstanceMethods
-        def _raw(input)
-          ::Lotus::Utils::Escape::SafeString.new(input)
+        private
+        # Mark the given string as safe to render.
+        #
+        # !!! ATTENTION !!! This may open your application to XSS attacks.
+        #
+        # @param string [String] the input string
+        #
+        # @return [Lotus::Utils::Escape::SafeString] the string marked as safe
+        #
+        # @since x.x.x
+        # @api public
+        #
+        # @example View usage
+        #   require 'lotus/view'
+        #
+        #   User = Struct.new(:name)
+        #
+        #   module Users
+        #     class Show
+        #       include Lotus::View
+        #
+        #       def user_name
+        #         _raw user.name
+        #       end
+        #     end
+        #   end
+        #
+        #   # ERB template
+        #   # <div id="user_name"><%= user_name %></div>
+        #
+        #   user = User.new("<script>alert('xss')</script>")
+        #   html = Users::Show.render(format: :html, user: user)
+        #
+        #   html # => <div id="user_name"><script>alert('xss')</script></div>
+        #
+        # @example Presenter usage
+        #   require 'lotus/view'
+        #
+        #   User = Struct.new(:name)
+        #
+        #   class UserPresenter
+        #     include Lotus::Presenter
+        #
+        #     def name
+        #       _raw @object.name
+        #     end
+        #   end
+        #
+        #   user      = User.new("<script>alert('xss')</script>")
+        #   presenter = UserPresenter.new(user)
+        #
+        #   presenter.name # => "<script>alert('xss')</script>"
+        def _raw(string)
+          ::Lotus::Utils::Escape::SafeString.new(string)
         end
 
+        # Force the output escape for the given object
+        #
+        # @param object [Object] the input object
+        #
+        # @return [Lotus::View::Escape::Presenter] a presenter with output
+        #   autoescape
+        #
+        # @since x.x.x
+        # @api public
+        #
+        # @see Lotus::View::Escape::Presenter
+        #
+        # @example View usage
+        #   require 'lotus/view'
+        #
+        #   User = Struct.new(:first_name, :last_name)
+        #
+        #   module Users
+        #     class Show
+        #       include Lotus::View
+        #
+        #       def user
+        #         _escape locals[:user]
+        #       end
+        #     end
+        #   end
+        #
+        #   # ERB template:
+        #   #
+        #   # <div id="first_name">
+        #   #   <%= user.first_name %>
+        #   # </div>
+        #   # <div id="last_name">
+        #   #   <%= user.last_name %>
+        #   # </div>
+        #
+        #   first_name = "<script>alert('first_name')</script>"
+        #   last_name  = "<script>alert('last_name')</script>"
+        #
+        #   user = User.new(first_name, last_name)
+        #   html = Users::Show.render(format: :html, user: user)
+        #
+        #   html
+        #     # =>
+        #     # <div id="first_name">
+        #     #   &lt;script&gt;alert(&apos;first_name&apos;)&lt;&#x2F;script&gt;
+        #     # </div>
+        #     # <div id="last_name">
+        #     #   &lt;script&gt;alert(&apos;last_name&apos;)&lt;&#x2F;script&gt;
+        #     # </div>
         def _escape(object)
           ::Lotus::View::Escape::Presenter.new(object)
         end
       end
 
+      # Auto escape presenter
+      #
+      # @since x.x.x
+      # @api private
+      #
+      # @see Lotus::View::Escape::InstanceMethods#_escape
       class Presenter
         include ::Lotus::Presenter
       end
 
+      # Escape the given input if it's a string, otherwise return the oject as it is.
+      #
+      # @param input [Object] the input
+      #
+      # @return [Object,String] the escaped string or the given object
+      #
+      # @since x.x.x
+      # @api private
       def self.html(input)
         case input
         when String
@@ -27,6 +146,10 @@ module Lotus
         end
       end
 
+      # Module extended override
+      #
+      # @since x.x.x
+      # @api private
       def self.extended(base)
         base.class_eval do
           include ::Lotus::Utils::ClassAttribute
@@ -37,6 +160,10 @@ module Lotus
         end
       end
 
+      # Wraps concrete view methods with escape logic.
+      #
+      # @since x.x.x
+      # @api private
       def method_added(method_name)
         unless autoescape_methods[method_name]
           prepend Module.new {

--- a/lib/lotus/view/escape.rb
+++ b/lib/lotus/view/escape.rb
@@ -1,8 +1,23 @@
 require 'lotus/utils/escape'
+require 'lotus/presenter'
 
 module Lotus
   module View
     module Escape
+      module InstanceMethods
+        def _raw(input)
+          ::Lotus::Utils::Escape::SafeString.new(input)
+        end
+
+        def _escape(object)
+          ::Lotus::View::Escape::Presenter.new(object)
+        end
+      end
+
+      class Presenter
+        include ::Lotus::Presenter
+      end
+
       def self.html(input)
         case input
         when String
@@ -14,8 +29,8 @@ module Lotus
 
       def self.extended(base)
         base.class_eval do
-          include Lotus::Utils::ClassAttribute
-          include InstanceMethods
+          include ::Lotus::Utils::ClassAttribute
+          include ::Lotus::View::Escape::InstanceMethods
 
           class_attribute :autoescape_methods
           self.autoescape_methods = {}
@@ -31,12 +46,6 @@ module Lotus
           }
 
           autoescape_methods[method_name] = true
-        end
-      end
-
-      module InstanceMethods
-        def raw(input)
-          Lotus::Utils::Escape::SafeString.new(input)
         end
       end
     end

--- a/lib/lotus/view/rendering/scope.rb
+++ b/lib/lotus/view/rendering/scope.rb
@@ -1,3 +1,4 @@
+require 'lotus/utils/escape'
 require 'lotus/view/rendering/layout_scope'
 require 'lotus/view/rendering/template'
 require 'lotus/view/rendering/partial'
@@ -59,13 +60,15 @@ module Lotus
 
         protected
         def method_missing(m, *args, &block)
-          if @view.respond_to?(m)
-            @view.__send__ m, *args, &block
-          elsif @locals.key?(m)
-            @locals[m]
-          else
-            super
-          end
+          ::Lotus::View::Escape.html(
+            if @view.respond_to?(m)
+              @view.__send__ m, *args, &block
+            elsif @locals.key?(m)
+              @locals[m]
+            else
+              super
+            end
+          )
         end
       end
     end

--- a/test/escape_test.rb
+++ b/test/escape_test.rb
@@ -34,4 +34,18 @@ describe 'Escape' do
     Users::Show.autoescape_methods.must_equal({custom: true, username: true, raw_username: true, book: true})
     Users::Extra.autoescape_methods.must_equal({username: true})
   end
+
+  it "escapes custom rendering" do
+    user = User.new('L')
+    xml  = Users::Show.render(format: :xml, user: user)
+
+    xml.must_match %(&lt;username&gt;L&lt;&#x2F;username&gt;)
+  end
+
+  it "works with raw contents in custom rendering" do
+    user = User.new('L')
+    json = Users::Show.render(format: :json, user: user)
+
+    json.must_match %({"username":"L"})
+  end
 end

--- a/test/escape_test.rb
+++ b/test/escape_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+describe 'Escape' do
+  before do
+    path     = Pathname.new(__dir__ + '/fixtures/templates/users/show.html.erb')
+    template = Lotus::View::Template.new(path)
+
+    @user = User.new(%(<script>alert('username')</script>))
+    @view = Users::Show.new(template, user: @user, code: %(<script>alert('code')</script>))
+  end
+
+  it 'escapes concrete method' do
+    @view.custom.must_equal %(&lt;script&gt;alert(&apos;custom&apos;)&lt;&#x2F;script&gt;)
+  end
+
+  it 'escapes concrete methods with user input' do
+    @view.username.must_equal %(&lt;script&gt;alert(&apos;username&apos;)&lt;&#x2F;script&gt;)
+  end
+
+  it 'escapes implicit methods' do
+    @view.code.must_equal %(&lt;script&gt;alert(&apos;code&apos;)&lt;&#x2F;script&gt;)
+  end
+
+  it "doesn't escape concrete raw methods" do
+    @view.raw_username.must_equal %(<script>alert('username')</script>)
+  end
+
+  it "doesn't interfer with other views" do
+    Users::Show.autoescape_methods.must_equal({custom: true, username: true, raw_username: true})
+    Users::Extra.autoescape_methods.must_equal({username: true})
+  end
+end

--- a/test/escape_test.rb
+++ b/test/escape_test.rb
@@ -6,7 +6,8 @@ describe 'Escape' do
     template = Lotus::View::Template.new(path)
 
     @user = User.new(%(<script>alert('username')</script>))
-    @view = Users::Show.new(template, user: @user, code: %(<script>alert('code')</script>))
+    @book = Book.new(%(<script>alert('title')</script>))
+    @view = Users::Show.new(template, user: @user, book: @book, code: %(<script>alert('code')</script>))
   end
 
   it 'escapes concrete method' do
@@ -25,8 +26,12 @@ describe 'Escape' do
     @view.raw_username.must_equal %(<script>alert('username')</script>)
   end
 
+  it 'escapes objects' do
+    @view.book.title.must_equal %(&lt;script&gt;alert(&apos;title&apos;)&lt;&#x2F;script&gt;)
+  end
+
   it "doesn't interfer with other views" do
-    Users::Show.autoescape_methods.must_equal({custom: true, username: true, raw_username: true})
+    Users::Show.autoescape_methods.must_equal({custom: true, username: true, raw_username: true, book: true})
     Users::Extra.autoescape_methods.must_equal({username: true})
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -145,6 +145,10 @@ class Map
   def location_names
     @locations.join(', ')
   end
+
+  def names
+    location_names
+  end
 end
 
 class MapPresenter
@@ -158,8 +162,16 @@ class MapPresenter
     super.upcase
   end
 
+  def escaped_location_names
+    @object.location_names
+  end
+
+  def raw_location_names
+    _raw @object.location_names
+  end
+
   def inspect_object
-    @object.inspect
+    _raw @object.inspect
   end
 end
 
@@ -196,7 +208,7 @@ module Songs
     format :html
 
     def render
-      raw SongWidget.new(song).render
+      _raw SongWidget.new(song).render
     end
   end
 end
@@ -313,6 +325,7 @@ end
 Store::View.load!
 
 User = Struct.new(:username)
+Book = Struct.new(:title)
 
 class UserLayout
   include Lotus::Layout
@@ -336,7 +349,11 @@ module Users
     end
 
     def raw_username
-      raw user.username
+      _raw user.username
+    end
+
+    def book
+      _escape(locals[:book])
     end
   end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 class HelloWorldView
   include Lotus::View
 end
@@ -327,6 +329,18 @@ Store::View.load!
 User = Struct.new(:username)
 Book = Struct.new(:title)
 
+class UserXmlSerializer
+  def initialize(user)
+    @user = user
+  end
+
+  def serialize
+    @user.to_h.map do |attr, value|
+      %(<#{ attr }>#{ value }</#{ attr }>)
+    end.join("\n")
+  end
+end
+
 class UserLayout
   include Lotus::Layout
 
@@ -354,6 +368,22 @@ module Users
 
     def book
       _escape(locals[:book])
+    end
+  end
+
+  class XmlShow < Show
+    format :xml
+
+    def render
+      UserXmlSerializer.new(user).serialize
+    end
+  end
+
+  class JsonShow < Show
+    format :json
+
+    def render
+      _raw JSON.generate(user.to_h)
     end
   end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -196,7 +196,7 @@ module Songs
     format :html
 
     def render
-      SongWidget.new(song).render
+      raw SongWidget.new(song).render
     end
   end
 end
@@ -311,3 +311,40 @@ module Store
 end
 
 Store::View.load!
+
+User = Struct.new(:username)
+
+class UserLayout
+  include Lotus::Layout
+
+  def page_title(username)
+    "User: #{ username }"
+  end
+end
+
+module Users
+  class Show
+    include Lotus::View
+    layout :user
+
+    def custom
+      %(<script>alert('custom')</script>)
+    end
+
+    def username
+      user.username
+    end
+
+    def raw_username
+      raw user.username
+    end
+  end
+
+  class Extra
+    include Lotus::View
+
+    def username
+      user.username
+    end
+  end
+end

--- a/test/fixtures/templates/user.html.erb
+++ b/test/fixtures/templates/user.html.erb
@@ -1,0 +1,15 @@
+<!doctype HTML>
+<html>
+  <head>
+    <title><%= page_title username %></title>
+  </head>
+  <body>
+    <div id="content">
+      <%= yield %>
+    </div>
+
+    <aside id="sidebar">
+      <span class="username"><%= username %></span>
+    </aside>
+  </body>
+</html>

--- a/test/fixtures/templates/users/show.html.erb
+++ b/test/fixtures/templates/users/show.html.erb
@@ -1,0 +1,5 @@
+<%= custom %>
+<%= username %>
+<%= code %>
+
+<%= raw_username %>

--- a/test/fixtures/templates/users/show.html.erb
+++ b/test/fixtures/templates/users/show.html.erb
@@ -2,4 +2,5 @@
 <%= username %>
 <%= code %>
 
-<%= raw_username %>
+<div id="raw_username"><%= raw_username %></div>
+<div id="book"><%= book.title %></div>

--- a/test/integration/automatic_escape_test.rb
+++ b/test/integration/automatic_escape_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+describe 'Automatic escape' do
+  before do
+    @user     = User.new(%(<script>alert('username')</script>))
+    @rendered = Users::Show.render(format: :html, user: @user, code: %(<script>alert('code')</script>))
+  end
+
+  it 'escapes concrete methods' do
+    @rendered.must_match %(&lt;script&gt;alert(&apos;custom&apos;)&lt;&#x2F;script&gt;)
+  end
+
+  it 'escapes concrete methods with user input' do
+    @rendered.must_match %(&lt;script&gt;alert(&apos;username&apos;)&lt;&#x2F;script&gt;)
+  end
+
+  it 'escapes implicit methods' do
+    @rendered.must_match %(&lt;script&gt;alert(&apos;code&apos;)&lt;&#x2F;script&gt;)
+  end
+
+  it "doesn't escape concrete raw methods" do
+    @rendered.must_match %(<script>alert('username')</script>)
+  end
+
+  it 'escapes concrete methods in layout' do
+    @rendered.must_match %(<span class="username">&lt;script&gt;alert(&apos;username&apos;)&lt;&#x2F;script&gt;</span>)
+  end
+
+  it 'escapes concrete helpers in layout' do
+    @rendered.must_match %(<title>User: &lt;script&gt;alert(&apos;username&apos;)&lt;&#x2F;script&gt;</title>)
+  end
+end

--- a/test/integration/automatic_escape_test.rb
+++ b/test/integration/automatic_escape_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 describe 'Automatic escape' do
   before do
     @user     = User.new(%(<script>alert('username')</script>))
-    @rendered = Users::Show.render(format: :html, user: @user, code: %(<script>alert('code')</script>))
+    @book     = Book.new(%(<script>alert('title')</script>))
+    @rendered = Users::Show.render(format: :html, user: @user, book: @book, code: %(<script>alert('code')</script>))
   end
 
   it 'escapes concrete methods' do
@@ -19,7 +20,7 @@ describe 'Automatic escape' do
   end
 
   it "doesn't escape concrete raw methods" do
-    @rendered.must_match %(<script>alert('username')</script>)
+    @rendered.must_match %(<div id="raw_username"><script>alert('username')</script></div>)
   end
 
   it 'escapes concrete methods in layout' do
@@ -28,5 +29,9 @@ describe 'Automatic escape' do
 
   it 'escapes concrete helpers in layout' do
     @rendered.must_match %(<title>User: &lt;script&gt;alert(&apos;username&apos;)&lt;&#x2F;script&gt;</title>)
+  end
+
+  it 'escapes objects' do
+    @rendered.must_match %(<div id="book">&lt;script&gt;alert(&apos;title&apos;)&lt;&#x2F;script&gt;</div>)
   end
 end

--- a/test/presenter_test.rb
+++ b/test/presenter_test.rb
@@ -28,6 +28,26 @@ describe Lotus::Presenter do
     subject.wont_respond_to :unknown_method
   end
 
+  describe 'escape' do
+    let(:map) { Map.new(["<script>alert('rome')</script>"]) }
+
+    it 'auto escapes contents' do
+      subject.location_names.must_equal %(&LT;SCRIPT&GT;ALERT(&APOS;ROME&APOS;)&LT;&#X2F;SCRIPT&GT;)
+    end
+
+    it 'auto escapes inherited methods' do
+      subject.names.must_equal %(&lt;script&gt;alert(&apos;rome&apos;)&lt;&#x2F;script&gt;)
+    end
+
+    it 'auto escapes concrete methods' do
+      subject.escaped_location_names.must_equal %(&lt;script&gt;alert(&apos;rome&apos;)&lt;&#x2F;script&gt;)
+    end
+
+    it 'allows raw contents' do
+      subject.raw_location_names.must_equal map.location_names
+    end
+  end
+
   it "raises error when the requested method can't be satisfied" do
     -> {
       subject.unknown_method


### PR DESCRIPTION
Starting from now, the output of views and presenters is always **autoescaped**.

Because Lotus::View supports a lot of template engines, the escape happens at the level of the view and it doesn't delegate to ERB or HAML.

Most of the time everything happens automatically, but there are still some corner cases that need developer's manual intervention.

#### View autoescape

```ruby
require 'lotus/view'

User = Struct.new(:name)

module Users
  class Show
    include Lotus::View

    def user_name
      user.name
    end
  end
end

# ERB template
# <div id="user_name"><%= user_name %></div>

user = User.new("<script>alert('xss')</script>")

# THIS IS USEFUL FOR UNIT TESTING:
template = Lotus::View::Template.new('users/show.html.erb')
view     = Users::Show.new(template, user: user)
view.user_name # => "&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;"

# THIS IS THE RENDERING OUTPUT:
Users::Show.render(format: :html, user: user)
# => <div id="user_name">&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;</div>
```

#### Presenter autoescape

```ruby
require 'lotus/view'

User = Struct.new(:name)

class UserPresenter
  include Lotus::Presenter
end

user      = User.new("<script>alert('xss')</script>")
presenter = UserPresenter.new(user)

presenter.name # => "&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;"
```

#### Escape entire objects

We have seen that concrete methods are in views are automatically escaped.
This is great, but tedious if you need to print a lot of informations from a given object.

Imagine to have `user` as part of the view locals.
If you want to use `<%= user.name %>` directly, **you're still vulnerable to XSS attacks**.

You have two alternatives to fix the problem:

  * To use a concrete presenter (eg. `UserPresenter`, example above)
  * Escape the entire object (example below)

Both those solutions allow you to keep the template syntax unchanged (`<%= user.name %>`), but to get a **safe output**.

```ruby
require 'lotus/view'

User = Struct.new(:first_name, :last_name)

module Users
  class Show
    include Lotus::View

    def user
      _escape locals[:user]
    end
  end
end

# ERB template:
#
# <div id="first_name">
#   <%= user.first_name %>
# </div>
# <div id="last_name">
#   <%= user.last_name %>
# </div>

first_name = "<script>alert('first_name')</script>"
last_name  = "<script>alert('last_name')</script>"

user = User.new(first_name, last_name)
html = Users::Show.render(format: :html, user: user)

html
  # =>
  # <div id="first_name">
  #   &lt;script&gt;alert(&apos;first_name&apos;)&lt;&#x2F;script&gt;
  # </div>
  # <div id="last_name">
  #   &lt;script&gt;alert(&apos;last_name&apos;)&lt;&#x2F;script&gt;
  # </div>
```

#### Raw contents

You can use `_raw` to mark an output as safe.
Please note that **this may open your application to XSS attacks.**

#### Raw contents in views

```ruby
require 'lotus/view'

User = Struct.new(:name)

module Users
  class Show
    include Lotus::View

    def user_name
      _raw user.name
    end
  end
end

# ERB template
# <div id="user_name"><%= user_name %></div>

user = User.new("<script>alert('xss')</script>")
html = Users::Show.render(format: :html, user: user)

html
# => <div id="user_name"><script>alert('xss')</script></div>
```

#### Raw contents in presenters

```ruby
require 'lotus/view'

User = Struct.new(:name)

class UserPresenter
  include Lotus::Presenter

  def first_name
    _raw @object.first_name
  end
end

user      = User.new("<script>alert('xss')</script>")
presenter = UserPresenter.new(user)

presenter.name # => "<script>alert('xss')</script>"
```