### PR TITLE
Fix disable layout in a view

### DIFF
--- a/lib/lotus/view/dsl.rb
+++ b/lib/lotus/view/dsl.rb
@@ -212,12 +212,13 @@ module Lotus
       end
 
       # When a value is given, it specifies the layout.
+      # When false is given, Lotus::View::Rendering::NullLayout is returned.
       # Otherwise, it returns the previously specified layout.
       #
       # When the global configuration is set (`Lotus::View.layout=`), after the
       # loading process, it will return that layout if not otherwise specified.
       #
-      # @param value [Symbol,nil] the layout name
+      # @param value [Symbol, FalseClass, nil] the layout name
       #
       # @return [Symbol, nil] the specified layout for this view, if set
       #
@@ -294,9 +295,28 @@ module Lotus
       #
       #   Lotus::View.load!
       #   Articles::Show.layout # => :articles
+      #
+      # @example Disable layout for the view
+      #   require 'lotus/view'
+      #
+      #   class ApplicationLayout
+      #     include Lotus::Layout
+      #   end
+      #
+      #   module Articles
+      #     class Show
+      #       include Lotus::View
+      #       layout false
+      #     end
+      #   end
+      #
+      #   Lotus::View.load!
+      #   Articles::Show.layout # => Lotus::View::Rendering::NullLayout
       def layout(value = nil)
         if value.nil?
           @_layout ||= Rendering::LayoutFinder.find(@layout || configuration.layout, configuration.namespace)
+        elsif !value
+          @layout = Lotus::View::Rendering::NullLayout
         else
           @layout = value
         end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -4,6 +4,11 @@ class HelloWorldView
   include Lotus::View
 end
 
+class DisabledLayoutView
+  include Lotus::View
+  layout false
+end
+
 class RenderView
   include Lotus::View
 end
@@ -275,6 +280,11 @@ module CardDeck
       class JsonIndex < Index
         format :json
         layout nil
+      end
+
+      class RssIndex < Index
+        format :rss
+        layout false
       end
     end
   end

--- a/test/integration/configuration_test.rb
+++ b/test/integration/configuration_test.rb
@@ -35,6 +35,10 @@ describe 'Framework configuration' do
     modules.must_include(::MyOtherCustomModule)
   end
 
+  it 'in a view disable a layout' do
+    CardDeck::Views::Home::RssIndex.layout.must_equal Lotus::View::Rendering::NullLayout
+  end
+
   it 'allow views to specify a layout'
   # TODO move all the values into the configuration:
   #

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -26,4 +26,10 @@ describe Lotus::Layout do
     rendered.must_match %(script)
     rendered.must_match %(yeah)
   end
+
+  describe 'disable layout in view' do
+    it 'return NullLayout' do
+      DisabledLayoutView.layout.must_equal Lotus::View::Rendering::NullLayout
+    end
+  end
 end


### PR DESCRIPTION
Closes #64 

What do you think with this approach to disable a layout in a view?

The problem is if you get the layout of a view without setting a new layout, then use configuration.layout in lotus apps

@jodosha @joneslee85 @gzigzigzeo