### PR TITLE
Render optional contents with #content_for

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,46 @@ Articles::Index.render(format: :rss)  # => Will use nothing
 
 As per convention, layout templates are located under `Lotus::View.root` or `ApplicationLayout.root` and use the underscored name (eg. `ApplicationLayout => application.html.erb`).
 
+### Content For
+
+If we want to render optional contents such as sidebar links or page specific javascripts, we can use `content_for`
+It accepts a key that represents a method that should be available within the rendering context.
+That context is made of the locals, and the methods that view and layout respond to.
+If the context can't dispatch that method, it returns `nil`.
+
+Given the following layout template.
+
+```erb
+<!doctype HTML>
+<html>
+  <!-- ... -->
+  <body>
+    <!-- ... -->
+    <%= content_for :footer %>
+  </body>
+</html>
+```
+
+We have two views, one responds to `#footer` (`Products::Show`) and the other doesn't (`Products::Index`).
+When the first is rendered, `content_for` gives back the returning value of `#footer`.
+In the other case, `content_for` returns `nil`.
+
+```ruby
+module Products
+  class Index
+    include Lotus::View
+  end
+
+  class Show
+    include Lotus::View
+
+    def footer
+      "contents for footer"
+    end
+  end
+end
+```
+
 ### Presenters
 
 The goal of a presenter is to wrap and reuse presentational logic for an object.

--- a/lib/lotus/view/rendering/layout_scope.rb
+++ b/lib/lotus/view/rendering/layout_scope.rb
@@ -111,6 +111,53 @@ module Lotus
           @locals || @scope.locals
         end
 
+        # Returns a content for the given key, by trying to invoke on the current
+        # scope, a method with the same name.
+        #
+        # The scope is made of locals and concrete methods from view and layout.
+        #
+        # @param key [Symbol] a method to invoke within current scope
+        # @return [String,NilClass] returning content if scope respond to the
+        #   requested method
+        #
+        # @since x.x.x
+        #
+        # @example
+        #   # Given the following layout template
+        #
+        #   <!doctype HTML>
+        #   <html>
+        #     <!-- ... -->
+        #     <body>
+        #       <!-- ... -->
+        #       <%= content_for :footer %>
+        #     </body>
+        #   </html>
+        #
+        #   # Case 1:
+        #   #   Products::Index doesn't respond to #footer, content_for will return nil
+        #   #
+        #   # Case 2:
+        #   #   Products::Show responds to #footer, content_for will send back
+        #   #     #footer returning value
+        #
+        #   module Products
+        #     class Index
+        #       include Lotus::View
+        #     end
+        #
+        #     class Show
+        #       include Lotus::View
+        #
+        #       def footer
+        #         "contents for footer"
+        #       end
+        #     end
+        #   end
+        def content_for(key)
+          __send__(key) if respond_to?(key)
+        end
+
         # Implements "respond to" logic
         #
         # @return [TrueClass,FalseClass]

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -322,6 +322,10 @@ module Store
     class StoreLayout
       include Store::Layout
       include Store::Helpers::AssetTagHelpers
+
+      def head
+        %(<meta name="lotusrb-version" content="0.3.1">)
+      end
     end
 
     module Home
@@ -333,6 +337,17 @@ module Store
 
       class JsonIndex < Index
         format :json
+      end
+    end
+
+    module Products
+      class Show
+        include Store::View
+        layout :store
+
+        def footer
+          _raw %(<script src="/javascripts/product-tracking.js"></script>)
+        end
       end
     end
   end

--- a/test/fixtures/templates/store/templates/products/show.html.erb
+++ b/test/fixtures/templates/store/templates/products/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Product</h1>script

--- a/test/fixtures/templates/store/templates/store.html.erb
+++ b/test/fixtures/templates/store/templates/store.html.erb
@@ -3,9 +3,11 @@
   <head>
     <title>Store</title>
     <%= javascript_tag 'application' %>
+    <%= content_for :head %>
   </head>
 
   <body>
     <%= yield %>
+    <%= content_for :footer %>
   </body>
 </html>

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -27,6 +27,18 @@ describe Lotus::Layout do
     rendered.must_match %(yeah)
   end
 
+  it 'renders content_for to return value from view' do
+    rendered = Store::Views::Products::Show.render(format: :html)
+    rendered.must_match %(Product)
+    rendered.must_match %(<script src="/javascripts/product-tracking.js"></script>)
+  end
+
+  it 'renders content_for to return value from layout' do
+    rendered = Store::Views::Products::Show.render(format: :html)
+    rendered.must_match %(Product)
+    rendered.must_match %(<meta name="lotusrb-version" content="0.3.1">)
+  end
+
   describe 'disable layout in view' do
     it 'return NullLayout' do
       DisabledLayoutView.layout.must_equal Lotus::View::Rendering::NullLayout


### PR DESCRIPTION
If we want to render optional contents such as sidebar links or page specific javascripts, we can use `content_for`
It accepts a key that represents a method that should be available within the rendering context.
That context is made of the locals, and the methods that view and layout respond to.
If the context can't dispatch that method, it returns `nil`.

Given the following layout template.

```erb
<!doctype HTML>
<html>
  <!-- ... -->
  <body>
    <!-- ... -->
    <%= content_for :footer %>
  </body>
</html>
```

We have two views, one responds to `#footer` (`Products::Show`) and the other doesn't (`Products::Index`).
When the first is rendered, `content_for` gives back the returning value of `#footer`.
In the other case, `content_for` returns `nil`.

```ruby
module Products
  class Index
    include Lotus::View
  end

  class Show
    include Lotus::View

    def footer
      "contents for footer"
    end
  end
end
```