### PR TITLE
Add JRuby Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: ruby
 script: 'bundle exec rake test:coverage'
 sudo: false
 cache: bundler
+install: true
+env:
+  global:
+    - JRUBY_OPTS=--dev
+script:
+  - 'if [[ "$TRAVIS_RUBY_VERSION" =~ "jruby" ]]; then rvm get head && rvm reload && rvm use --install $TRAVIS_RUBY_VERSION; fi'
+  - 'bundle install'
+  - 'bundle exec rake test:coverage'
 rvm:
   - 2.0.0
   - 2.1.0
@@ -16,13 +24,11 @@ rvm:
   - 2.2.1
   - 2.2.2
   - 2.2.3
+  - jruby-9000
+  - jruby-head
   - rbx-2
 
 matrix:
-  include:
-    - rvm: jruby-head
-    - rvm: jruby-9000
   allow_failures:
     - rvm: rbx-2
     - rvm: jruby-head
-    - rvm: jruby-9000

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 unless ENV['TRAVIS']
   gem 'byebug', require: false, platforms: :mri if RUBY_VERSION >= '2.1.0'
+  gem 'pry',    require: false, platforms: :jruby
   gem 'yard',   require: false
 end
 

--- a/lib/lotus/view.rb
+++ b/lib/lotus/view.rb
@@ -268,9 +268,9 @@ module Lotus
       conf.add_view(base)
 
       base.class_eval do
-        extend Inheritable.dup
-        extend Dsl.dup
-        extend Rendering.dup
+        extend Inheritable
+        extend Dsl
+        extend Rendering
         extend Escape.dup
 
         include Utils::ClassAttribute

--- a/lib/lotus/view/dsl.rb
+++ b/lib/lotus/view/dsl.rb
@@ -205,9 +205,9 @@ module Lotus
       #   Bookshelf::Api::Views::Books::Index.template # => 'books/index'
       def template(value = nil)
         if value.nil?
-          @@template ||= Rendering::TemplateName.new(name, configuration.namespace).to_s
+          @template ||= Rendering::TemplateName.new(name, configuration.namespace).to_s
         else
-          @@template = value
+          @template = value
         end
       end
 

--- a/lib/lotus/view/inheritable.rb
+++ b/lib/lotus/view/inheritable.rb
@@ -27,7 +27,7 @@ module Lotus
       # @api private
       # @since 0.1.0
       def subclasses
-        @@subclasses ||= Set.new
+        @subclasses ||= Set.new
       end
 
       protected
@@ -47,7 +47,7 @@ module Lotus
       # @api private
       # @since 0.1.0
       def views
-        @@views ||= [ self ] + subclasses.to_a
+        @views ||= [ self ] + subclasses.to_a
       end
     end
   end

--- a/lib/lotus/view/rendering.rb
+++ b/lib/lotus/view/rendering.rb
@@ -258,7 +258,7 @@ module Lotus
       #
       # @see Lotus::View::Rendering::Registry
       def registry
-        @@registry ||= Registry.new(self)
+        @registry ||= Registry.new(self)
       end
     end
   end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -209,6 +209,7 @@ end
 
 class IndexView
   include Lotus::View
+
   layout :application
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'bundler/setup'
+require 'tilt/erb'
 
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'


### PR DESCRIPTION
In face of JRuby issue to a particular MRI behavior involving lexical
escope of `cvar`s of duped classes, this commit changes the approach by
using instance vars without duping classes.

Note: Even though it's a JRuby issue
https://github.com/jruby/jruby/issues/2988#issuecomment-126820250
I decided to change Lotus implementation because of the complexity of
fixing it on JRuby side (second its core maintainers).

Ref. https://github.com/lotus/lotus/pull/307