### PR TITLE
Performance improvement of Lotus::Layout.template

### DIFF
--- a/lib/lotus/layout.rb
+++ b/lib/lotus/layout.rb
@@ -78,7 +78,7 @@ module Lotus
       #
       # ApplicationLayout.template # => 'application'
       def template
-        super.gsub(suffix, '')
+        super.sub(suffix, '')
       end
 
       # Template name suffix


### PR DESCRIPTION
We want to remove suffix only so we need replace only its first occurrence. `String#sub` in this case is more suitable here because of being faster than `String#gsub`.