### PR TITLE
Guarantee default encoding to exist

### DIFF
--- a/lib/lotus/view/configuration.rb
+++ b/lib/lotus/view/configuration.rb
@@ -33,7 +33,7 @@ module Lotus
       #
       # @since 0.5.0
       # @api private
-      DEFAULT_ENCODING = 'utf-8'.freeze
+      DEFAULT_ENCODING = Encoding::UTF_8
 
       attr_reader :load_paths
       attr_reader :views
@@ -243,11 +243,52 @@ module Lotus
         end
       end
 
+      # Default encoding for templates
+      #
+      # This is part of a DSL, for this reason when this method is called with
+      # an argument, it will set the corresponding instance variable. When
+      # called without, it will return the already set value, or the default.
+      #
+      # @overload default_encoding(value)
+      #   Sets the given value
+      #   @param value [String,Encoding] a string representation of the encoding,
+      #     or an Encoding constant
+      #
+      #   @raise [ArgumentError] if the given value isn't a supported encoding
+      #
+      # @overload default_encoding
+      #   Gets the value
+      #   @return [Encoding]
+      #
+      # @since 0.5.0
+      #
+      # @example Set UTF-8 As A String
+      #   require 'lotus/view'
+      #
+      #   Lotus::View.configure do
+      #     default_encoding 'utf-8'
+      #   end
+      #
+      # @example Set UTF-8 As An Encoding Constant
+      #   require 'lotus/view'
+      #
+      #   Lotus::View.configure do
+      #     default_encoding Encoding::UTF_8
+      #   end
+      #
+      # @example Raise An Error For Unknown Encoding
+      #   require 'lotus/view'
+      #
+      #   Lotus::View.configure do
+      #     default_encoding 'foo'
+      #   end
+      #
+      #     # => ArgumentError
       def default_encoding(value = nil)
         if value.nil?
           @default_encoding
         else
-          @default_encoding = value.to_s
+          @default_encoding = Encoding.find(value)
         end
       end
 

--- a/test/view/configuration_test.rb
+++ b/test/view/configuration_test.rb
@@ -144,13 +144,19 @@ describe Lotus::View::Configuration do
   end
 
   describe "#default_encoding" do
-    it 'defaults to "utf-8"' do
-      @configuration.default_encoding.must_equal "utf-8"
+    it 'defaults to Encoding::UTF_8' do
+      @configuration.default_encoding.must_equal Encoding::UTF_8
     end
 
     it 'allows to set different value' do
-      @configuration.default_encoding "koi-8"
-      @configuration.default_encoding.must_equal "koi-8"
+      encoding = Encoding.list.sample
+      @configuration.default_encoding encoding.to_s
+      @configuration.default_encoding.must_equal encoding
+    end
+
+    it 'raises error in case of unknown encoding' do
+      exception = -> { @configuration.default_encoding 'abc' }.must_raise ArgumentError
+      exception.message.must_equal 'unknown encoding name - abc'
     end
   end
 
@@ -193,7 +199,7 @@ describe Lotus::View::Configuration do
       @configuration.root 'test'
       @configuration.load_paths << '..'
       @configuration.layout :application
-      @configuration.default_encoding 'latin-1'
+      @configuration.default_encoding 'UTF-7'
       @configuration.add_view(HelloWorldView)
       @configuration.add_layout(ApplicationLayout)
       @configuration.prepare { include Kernel }
@@ -215,7 +221,7 @@ describe Lotus::View::Configuration do
       @config.root '.'
       @config.load_paths << '../..'
       @config.layout :global
-      @config.default_encoding 'iso-8859'
+      @config.default_encoding 'iso-8859-1'
       @config.add_view(RenderView)
       @config.add_layout(GlobalLayout)
       @config.prepare { include Comparable }
@@ -237,7 +243,7 @@ describe Lotus::View::Configuration do
       @configuration.load_paths.must_include '..'
       @configuration.load_paths.wont_include '../..'
 
-      @configuration.default_encoding.must_equal 'latin-1'
+      @configuration.default_encoding.must_equal Encoding::UTF_7
 
       @configuration.layout.must_equal     ApplicationLayout
 


### PR DESCRIPTION
Ditto.

---

Default encoding is now `Encoding::UTF_8`, instead of `"utf-8"`.
Developers can set the value with a string:

```ruby
Lotus::View.configure do
  default_encoding "ISO-8859-1"
end
```

or with a constant:

```ruby
Lotus::View.configure do
  default_encoding Encoding::ISO_8859_1
end
```

Invalid names will cause an `ArgumentError`

```ruby
Lotus::View.configure do
  default_encoding 'foo'
end

# => ArgumentError: unknown encoding name - foo
```

This _"fail fast"_ policy let developers to detect unsupported encodings at the startup time (in development or production), rather than later on when the application is up and running.

---

Thanks to @deepj for letting me to reflect on the poor handling that we had until now.

Ref: https://github.com/lotus/view/commit/2fe93731e5f84cd34de0d68e320b2e35db671a4a#commitcomment-15324075

/cc @lotus/core-team 